### PR TITLE
Add jbcl to GitHub Actions trust (external_repositories)

### DIFF
--- a/x-repos.tfvars
+++ b/x-repos.tfvars
@@ -12,5 +12,12 @@ external_repositories = {
     environments        = ["dev", "stg", "qa", "prd"]
     topics              = ["iam", "terraform", "oidc", "github-actions", "ci-cd"]
     visibility          = "public"
+  },
+  "jbcl" = {
+    description         = "JBCL — Film • Editorial • Media. Premium creative agency site (Next.js static export deployed to S3/CloudFront)."
+    has_dev_environment = true
+    environments        = ["dev"]
+    topics              = ["nextjs", "static-site", "s3", "cloudfront", "website"]
+    visibility          = "private"
   }
 }


### PR DESCRIPTION
## What

Adds `jbcl` to `external_repositories` in `x-repos.tfvars` so the shared GitHub Actions role trusts the private repo **thekloudwiz-org/jbcl** via OIDC.

The trust-policies module generates these subjects for it:
- `repo:thekloudwiz-org/jbcl:ref:refs/heads/dev`
- `repo:thekloudwiz-org/jbcl:environment:dev`
- `repo:thekloudwiz-org/jbcl:pull_request`

## Why

`jbcl` hosts the JBCL website (Next.js static export → S3 + CloudFront). Its deploy workflow assumes the shared role via OIDC (`environment: dev`). The trust entry was applied manually to unblock the first deploy; this codifies it so the role's trust policy is managed by Terraform.

## Why `external_repositories` (not `repositories`)

- The repo already exists (created outside this module), so it must not be re-created here.
- `external_repositories` feeds only the trust-policy subjects — it never reaches the repositories module, so **no branch protection** is applied (jbcl is a private repo on the free plan, where branch protection isn't available).