### PR TITLE
ci: bump workflow actions to Node 24 versions

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -33,7 +33,7 @@ jobs:
     if: success()
     steps:
       - name: Create Success Issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/repository-management.yml
+++ b/.github/workflows/repository-management.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -54,7 +54,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TF_VERSION }}
 

--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -39,17 +39,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: terraform-drift-${{ matrix.environment }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -83,7 +83,7 @@ jobs:
 
       - name: Create Drift Issue
         if: steps.check-drift.outputs.drift == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -139,7 +139,7 @@ jobs:
 
       - name: Comment on Success
         if: steps.check-drift.outputs.drift == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/terraform-reusable.yml
+++ b/.github/workflows/terraform-reusable.yml
@@ -37,7 +37,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -47,7 +47,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ inputs.terraform_version }}
           terraform_wrapper: false
@@ -133,7 +133,7 @@ jobs:
         run: cat /tmp/plan-output.txt || echo "No plan output captured"
 
       - name: Update Pull Request
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         if: github.event_name == 'pull_request' && inputs.action == 'plan'
         env:
           PLAN: ${{ steps.plan.outputs.stdout }}
@@ -177,7 +177,7 @@ jobs:
 
       - name: Create Issue on Failure
         if: failure() && inputs.action == 'apply'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GH_PAT }}
           script: |


### PR DESCRIPTION
## What

Bumps all GitHub Actions in the workflows to their Node 24 releases:

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4 | **v5** |
| `actions/github-script` | v7 | **v8** |
| `hashicorp/setup-terraform` | v3 | **v4** |
| `aws-actions/configure-aws-credentials` | v4 | **v6** |

## Why

GitHub is migrating runners off Node 20 (forced to Node 24 starting 2026-06-16; Node 20 removed 2026-09-16). The `branch-deploy` run flagged `checkout@v4` and `setup-terraform@v3` as deprecated. Each target version's `action.yml` was confirmed to declare `using: node24`.

The `configure-aws-credentials` bump also standardizes the one stray `@v4` to `@v6`, which the other jobs in these workflows already use.

## Risk

Major-version bumps, but inputs used here (`role-to-assume`, `aws-region`, `terraform_version`, `script`, `github-token`) are unchanged across these versions, and `configure-aws-credentials@v6` is already proven in this repo. Validated all workflow YAML parses; `branch-deploy` will exercise the new versions on merge.