### PR TITLE
feat(akyeba): require pr-gate + audit checks; add CloudWatch metrics read

### DIFF
--- a/global.tfvars
+++ b/global.tfvars
@@ -85,12 +85,13 @@ repositories = {
     code_owners         = ["kloudwiz", "developers", "devops", "wizreviewer"]
   },
   "akyeba" = {
-    description         = "Akyeba website"
-    has_dev_environment = true
-    environments        = ["dev", "stg", "qa", "prd"]
-    topics              = ["web"]
-    visibility          = "public"
-    code_owners         = ["kloudwiz", "developers", "devops", "wizreviewer"]
+    description            = "Akyeba website"
+    has_dev_environment    = true
+    environments           = ["dev", "stg", "qa", "prd"]
+    topics                 = ["web"]
+    visibility             = "public"
+    code_owners            = ["kloudwiz", "developers", "devops", "wizreviewer"]
+    required_status_checks = ["pr-gate", "audit"]
   },
 
   "portfolio" = {

--- a/modules/repositories/main.tf
+++ b/modules/repositories/main.tf
@@ -76,6 +76,19 @@ resource "github_branch_protection" "main" {
     required_approving_review_count = 0
   }
 
+  # Per-repo required CI checks (empty for repos that don't set them, so
+  # this is a no-op everywhere else). strict=false: don't force the branch
+  # to be rebuilt against a moved base — the checks already ran on the PR
+  # head. Use aggregator-style contexts (e.g. "pr-gate") for path-filtered
+  # pipelines so a skipped job can't deadlock the merge.
+  dynamic "required_status_checks" {
+    for_each = length(each.value.required_status_checks) > 0 ? [1] : []
+    content {
+      strict   = false
+      contexts = each.value.required_status_checks
+    }
+  }
+
   depends_on = [github_repository.repos]
 }
 
@@ -96,6 +109,14 @@ resource "github_branch_protection" "dev" {
     dismiss_stale_reviews           = true
     required_approving_review_count = 0
     require_code_owner_reviews      = lookup(each.value, "require_code_owner_reviews", false)
+  }
+
+  dynamic "required_status_checks" {
+    for_each = length(each.value.required_status_checks) > 0 ? [1] : []
+    content {
+      strict   = false
+      contexts = each.value.required_status_checks
+    }
   }
 
   depends_on = [github_repository.repos, github_branch.dev]

--- a/modules/repositories/variables.tf
+++ b/modules/repositories/variables.tf
@@ -13,6 +13,7 @@ variable "repositories" {
     visibility                 = string
     code_owners                = optional(list(string))
     require_code_owner_reviews = optional(bool, false)
+    required_status_checks     = optional(list(string), [])
   }))
   default = {} # Allow empty map for flexibility
 }

--- a/policies/deployment-permissions-5.json
+++ b/policies/deployment-permissions-5.json
@@ -115,6 +115,17 @@
       "Resource": "*"
     },
     {
+      "Sid": "CloudWatchMetricsRead",
+      "Effect": "Allow",
+      "Action": [
+        "cloudwatch:GetMetricStatistics",
+        "cloudwatch:GetMetricData",
+        "cloudwatch:ListMetrics",
+        "cloudwatch:DescribeAlarms"
+      ],
+      "Resource": "*"
+    },
+    {
       "Sid": "CacheServices",
       "Effect": "Allow",
       "Action": [

--- a/variables.tf
+++ b/variables.tf
@@ -75,12 +75,13 @@ variable "thumbprint_list" {
 variable "repositories" {
   description = "Map of repositories to create"
   type = map(object({
-    description         = string
-    has_dev_environment = bool
-    environments        = list(string)
-    topics              = list(string)
-    visibility          = string
-    code_owners         = optional(list(string), [])
+    description            = string
+    has_dev_environment    = bool
+    environments           = list(string)
+    topics                 = list(string)
+    visibility             = string
+    code_owners            = optional(list(string), [])
+    required_status_checks = optional(list(string), [])
   }))
   default = {}
 }


### PR DESCRIPTION
Enables the two iam-modules-side pieces for akyeba's new PR-gated flow + deploy canary.

## ⚠️ Review the terraform plan before merging
This repo applies on merge and manages the GitHub org/repos. **Confirm the plan only modifies branch-protection + the one IAM policy** — no repo create/destroy — before merging. (Per this repo's history, state drift here can delete repos.)

## 1. Branch protection — required checks (`modules/repositories`)
- New optional per-repo `required_status_checks` (default `[]` → **no change to any other repo**), wired into the `main` + `dev` protection resources via a dynamic block. `strict=false` (checks already ran on the PR head; don't force a rebuild on a moved base).
- akyeba set to `["pr-gate", "audit"]` — the always-running aggregator (covers the path-filtered lambda tests + terraform-validate) and the CVE audit. Requiring the aggregator avoids the *required-check-skipped → merge-blocked* deadlock that requiring the individual path-filtered jobs would cause.

## 2. CloudWatch metrics read (`policies/deployment-permissions-5.json`)
- New `CloudWatchMetricsRead` statement (`GetMetricStatistics`, `GetMetricData`, `ListMetrics`, `DescribeAlarms`).
- **Note:** the live `thekloudwiz-dev-github-actions-role` already has this via `thekloudwiz-wildcard-permissions`, so the deploy canary's auto-rollback works *today*. This only future-proofs the prod split-policy path (which had X-Ray but no CloudWatch).

## Ordering
akyeba's `pr-gate` aggregator already merged to akyeba `dev` (PR #75), so the `pr-gate` context exists — safe to enable the required check.

## Validation
`terraform validate` passes; my touched files are `fmt`-clean.