### PR TITLE
fix(ci): PR plans run under the read-only role, not the wildcard deploy role

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,5 +23,9 @@ jobs:
       action: plan
       terraform_version: '1.14.6'
     secrets:
-      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      # PR plans assume the READ-ONLY pull-request role, not the deploy role.
+      # The deploy role carries wildcard (*) perms on dev; a pull_request must
+      # not be able to obtain those. This role is scoped to pull_request OIDC
+      # subjects and granted read-only perms sufficient for `terraform plan`.
+      AWS_ROLE_ARN: ${{ secrets.AWS_PLAN_ROLE_ARN }}
       GH_PAT: ${{ secrets.GH_PAT }}

--- a/policies/read-only-permissions.json
+++ b/policies/read-only-permissions.json
@@ -13,6 +13,25 @@
       "Resource": "*"
     },
     {
+      "Sid": "IAMReadAccess",
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetRole",
+        "iam:GetRolePolicy",
+        "iam:ListRolePolicies",
+        "iam:ListAttachedRolePolicies",
+        "iam:ListInstanceProfilesForRole",
+        "iam:ListRoleTags",
+        "iam:GetPolicy",
+        "iam:GetPolicyVersion",
+        "iam:ListPolicyVersions",
+        "iam:ListPolicyTags",
+        "iam:GetOpenIDConnectProvider",
+        "iam:ListOpenIDConnectProviders"
+      ],
+      "Resource": "*"
+    },
+    {
       "Sid": "DynamoDBReadAccess",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
Closes the finding from #28: PR plans assumed the **wildcard deploy role**, so a `pull_request` could obtain `*` creds on the account. Now they assume the **read-only** role.

## Changes
1. **`pull-request.yml`** → assumes `secrets.AWS_PLAN_ROLE_ARN` (the read-only `thekloudwiz-dev-pull-request-role`) instead of `secrets.AWS_ROLE_ARN` (deploy role). Apply paths (`branch-deploy`, `production-deploy`) are untouched — they keep the deploy role.
2. **`read-only-permissions.json`** → added `IAMReadAccess` (GetRole/GetPolicy/GetOpenIDConnectProvider + the List/Get calls a refresh needs). The policy previously had S3/DynamoDB/EC2/ECS read but **no IAM read**, so a plan of this repo would have failed on refresh. Read-only only — no write/create/delete.

## New secret (already created)
`AWS_PLAN_ROLE_ARN = arn:aws:iam::288761729262:role/thekloudwiz-dev-pull-request-role`. I set it via `gh secret set`; no action needed.

## Plan (dev, CI var-files)
```
Plan: 0 to add, 2 to change, 0 to destroy.
  ~ aws_iam_policy.deployment_permissions["readonly"]   (IAMReadAccess added)
  ~ github_team_membership.all["kloudwiz"]              (pre-existing drift)
```

## Notes
- **Pairs with #28** (which scopes the read-only role's *trust* to `pull_request` only). This PR makes PR plans *use* that role; #28 makes sure nothing else can assume it. Merge both for the full hardening; order doesn't matter.
- **No backend lock table** is configured, and `plan` doesn't persist state, so S3 read + IAM read is sufficient (no write perms granted).
- **Validation caveat:** `pull-request.yml` only triggers on PRs to `main`, so this can't be exercised by a PR to `dev`. The real test is the next PR targeting `main` — it should plan green under the read-only role. If the refresh ever surfaces a missing read action, it's a one-line add to `IAMReadAccess`.