### PR TITLE
ci: run PR plan on dev PRs and make it a required check

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - dev
     paths:
       - '**.tf'
       - '**.tfvars'
@@ -15,11 +16,13 @@ permissions:
   pull-requests: write
 
 jobs:
-  plan-production:
-    name: Plan Production Changes
+  plan:
+    # Plan the environment that matches the PR's target branch: main -> prd,
+    # dev -> dev. So a PR to dev is reviewed against dev state, not prd.
+    name: Plan ${{ github.base_ref == 'main' && 'prd' || 'dev' }} Changes
     uses: ./.github/workflows/terraform-reusable.yml
     with:
-      environment: prd
+      environment: ${{ github.base_ref == 'main' && 'prd' || 'dev' }}
       action: plan
       terraform_version: '1.14.6'
     secrets:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,3 +32,19 @@ jobs:
       # subjects and granted read-only perms sufficient for `terraform plan`.
       AWS_ROLE_ARN: ${{ secrets.AWS_PLAN_ROLE_ARN }}
       GH_PAT: ${{ secrets.GH_PAT }}
+
+  # Stable-named gate for branch protection to require. The plan job's own
+  # check name is dynamic ("Plan <env> Changes / Terraform plan - <env>"),
+  # which can't be pinned as a required context; this job's name is constant.
+  plan-gate:
+    needs: [plan]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the plan to have succeeded
+        run: |
+          if [ "${{ needs.plan.result }}" != "success" ]; then
+            echo "::error::Terraform plan did not pass (result: ${{ needs.plan.result }})"
+            exit 1
+          fi
+          echo "Terraform plan passed."

--- a/main.tf
+++ b/main.tf
@@ -77,3 +77,30 @@ module "repositories" {
   project_name = var.project_name
   repositories = var.repositories
 }
+
+# Branch protection for this repo's own `dev` branch. iam-modules is an
+# external repo (not in var.repositories), so the repositories module doesn't
+# manage it — protect it here directly via a data lookup (no repo import).
+# Requires the `plan-gate` check (pull-request.yml) so a PR's terraform plan
+# must pass before merge, and requires PRs (0 approvals — solo contributor).
+data "github_repository" "self" {
+  name = "iam-modules"
+}
+
+resource "github_branch_protection" "self_dev" {
+  repository_id = data.github_repository.self.node_id
+  pattern       = "dev"
+
+  enforce_admins      = false
+  allows_force_pushes = true
+
+  required_pull_request_reviews {
+    dismiss_stale_reviews           = true
+    required_approving_review_count = 0
+  }
+
+  required_status_checks {
+    strict   = false
+    contexts = ["plan-gate"]
+  }
+}


### PR DESCRIPTION
Makes the iam-modules terraform plan run on **dev** PRs (planning the dev environment) and a **required** check before merge.

## Changes
1. **`pull-request.yml` fires on `dev` PRs too** — environment derived from the base branch (`main → prd`, `dev → dev`) so a dev PR is planned against dev state. Still runs under the read-only `AWS_PLAN_ROLE_ARN` role (#29).
2. **`plan-gate` job** — a stable-named gate (`needs: [plan]`) for branch protection to require. The plan job's own check name is dynamic (`Plan <env> Changes / Terraform plan - <env>`) and can't be pinned.
3. **`main.tf` → `github_branch_protection.self_dev`** — protects iam-modules' own `dev` branch (it's an *external* repo, so the repositories module doesn't manage it; done here via a `data.github_repository` lookup — no repo import). Requires `plan-gate` + PRs (0 approvals). iam-modules `dev` was previously **unprotected**.

## Plan (dev, CI var-files)
```
Plan: 1 to add, 1 to change, 0 to destroy.
  + github_branch_protection.self_dev          (requires plan-gate, PRs)
  ~ github_team_membership.all["kloudwiz"]     (pre-existing, unrelated drift)
```

## Ordering (no deadlock)
Merging this PR both lands the workflow (with `plan-gate`) on `dev` **and** creates the protection requiring it — so the next dev PR's `plan-gate` runs and satisfies the gate. This PR predates the change being on `dev`, so it isn't blocked by its own rule.

## Notes
- Safe re: `branch-deploy`: the reusable's auto-format `git push` only runs when `fmt` fails and is swallowed by `|| echo`, so protecting `dev` won't break applies.
- `main` branch is left as-is (this scopes to dev). Say the word to mirror `plan-gate` as required on `main` too.