### PR TITLE
ci: dev-only gates + manual approval on prod terraform apply

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -15,8 +15,36 @@ permissions:
   pull-requests: write
 
 jobs:
+  # IaC to prod is never a blind apply: plan first, require a human to review
+  # it and approve (the `production` GitHub Environment's required reviewers),
+  # then apply. A dev plan validates against dev state — it does NOT prove a
+  # clean prd apply — and a bad apply here can delete repos, so the prd plan
+  # must be seen before it runs.
+  plan:
+    name: Plan Production
+    uses: ./.github/workflows/terraform-reusable.yml
+    with:
+      environment: prd
+      action: plan
+      terraform_version: '1.14.6'
+    secrets:
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      GH_PAT: ${{ secrets.GH_PAT }}
+
+  approval:
+    name: Approve Production Apply
+    needs: plan
+    runs-on: ubuntu-latest
+    # Required reviewers on this environment pause the run here; the reviewer
+    # reads the plan job's output, then approves.
+    environment: production
+    steps:
+      - name: Approval gate
+        run: echo "Approved by @${{ github.actor }} — proceeding to terraform apply (prd)."
+
   deploy-production:
     name: Deploy to Production
+    needs: approval
     uses: ./.github/workflows/terraform-reusable.yml
     with:
       environment: prd
@@ -25,7 +53,7 @@ jobs:
     secrets:
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       GH_PAT: ${{ secrets.GH_PAT }}
-    
+
   notify-success:
     name: Notify Success
     needs: deploy-production

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,9 +1,10 @@
 name: Pull Request
 
+# Plans run on dev PRs only. main is deploy-only (production-deploy.yml applies
+# on push to main) — code reaching main was already planned + reviewed on dev.
 on:
   pull_request:
     branches:
-      - main
       - dev
     paths:
       - '**.tf'
@@ -17,12 +18,10 @@ permissions:
 
 jobs:
   plan:
-    # Plan the environment that matches the PR's target branch: main -> prd,
-    # dev -> dev. So a PR to dev is reviewed against dev state, not prd.
-    name: Plan ${{ github.base_ref == 'main' && 'prd' || 'dev' }} Changes
+    name: Plan dev Changes
     uses: ./.github/workflows/terraform-reusable.yml
     with:
-      environment: ${{ github.base_ref == 'main' && 'prd' || 'dev' }}
+      environment: dev
       action: plan
       terraform_version: '1.14.6'
     secrets:
@@ -34,8 +33,8 @@ jobs:
       GH_PAT: ${{ secrets.GH_PAT }}
 
   # Stable-named gate for branch protection to require. The plan job's own
-  # check name is dynamic ("Plan <env> Changes / Terraform plan - <env>"),
-  # which can't be pinned as a required context; this job's name is constant.
+  # check name is dynamic, which can't be pinned as a required context; this
+  # job's name is constant.
   plan-gate:
     needs: [plan]
     if: always()

--- a/modules/repositories/main.tf
+++ b/modules/repositories/main.tf
@@ -76,18 +76,10 @@ resource "github_branch_protection" "main" {
     required_approving_review_count = 0
   }
 
-  # Per-repo required CI checks (empty for repos that don't set them, so
-  # this is a no-op everywhere else). strict=false: don't force the branch
-  # to be rebuilt against a moved base — the checks already ran on the PR
-  # head. Use aggregator-style contexts (e.g. "pr-gate") for path-filtered
-  # pipelines so a skipped job can't deadlock the merge.
-  dynamic "required_status_checks" {
-    for_each = length(each.value.required_status_checks) > 0 ? [1] : []
-    content {
-      strict   = false
-      contexts = each.value.required_status_checks
-    }
-  }
+  # No required status checks on main: it's deploy-only. Tests, plans, and
+  # scans run as required checks on the dev branch; code reaching main was
+  # already validated there. required_status_checks is wired on the dev
+  # protection only (below).
 
   depends_on = [github_repository.repos]
 }

--- a/modules/roles/main.tf
+++ b/modules/roles/main.tf
@@ -130,3 +130,13 @@ resource "aws_iam_role_policy_attachment" "pull_request_policy" {
   role       = aws_iam_role.pull_request.name
   policy_arn = var.policy_arns["readonly"]
 }
+
+# AWS-managed ReadOnlyAccess so PR `terraform plan` jobs can refresh resources
+# across every service a product stack touches (lambda, apigw, cognito,
+# cloudfront, sns, ssm, kms, ...). The custom `readonly` policy above only
+# covers a handful of services — enough for this repo, not for akyeba/gyaale.
+# Read-only: a PR can refresh state but can't mutate anything.
+resource "aws_iam_role_policy_attachment" "pull_request_readonly_managed" {
+  role       = aws_iam_role.pull_request.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}


### PR DESCRIPTION
Implements the agreed model: **all tests/plans/scans run on dev; main is deploy-only** — plus a **manual-approval gate before any prod terraform apply**.

## Dev-only gates
- `pull-request.yml`: plan runs on **dev PRs only** (was main+dev), environment fixed to `dev`.
- `modules/repositories`: drop `required_status_checks` from the **main** branch protection (kept on dev). Code reaching main was already gated on its dev PR; main shouldn't re-gate. *(Removes the `pr-gate`/`audit` requirement from akyeba's main — intended.)*

## Prod apply = plan → approve → apply
`production-deploy.yml` is split:
1. `plan` (prd) — output visible in the job log.
2. `approval` — a job on the **`production`** GitHub Environment (required reviewer: `thekloudwiz`, already configured). The run pauses; reviewer reads the plan, approves.
3. `deploy-production` — the apply, runs only after approval.

Rationale: a dev plan validates dev state, not prd; and a bad apply here can delete repos. So prd never applies without a human seeing the prd plan.

## Notes
- The `production` environment is created with `prevent_self_review: false` (solo owner must self-approve) and no branch policy (the workflow already only runs on main).
- This prod path is currently **dormant** (no prd role exists; main isn't wired), so the gate is forward-looking — it'll be in force the moment prod is activated. When you wire prod, consider a prd **read-only** role for the `plan` job (mirrors the dev read-only plan role).
- Review the CI plan before merge (applies on merge to dev): expect `pull-request.yml` dev-only, akyeba main protection losing required checks, no resource destroys.